### PR TITLE
support simple add command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Sweesh/sweesh-cli#readme",
   "dependencies": {
+    "uuid": "^3.2.1",
     "yargs": "^11.0.0"
   },
   "devDependencies": {

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -1,0 +1,44 @@
+// @flow
+
+import path from 'path';
+import uuid from 'uuid';
+import fs from 'fs';
+import { promisify } from 'util';
+
+import resolve from '../utils/resolve';
+import fsResolver from '../utils/fsResolver';
+
+import type {Resolver, ChangeIntent} from '../utils/resolve';
+
+const backupDir = path.resolve(process.env.HOME, './.sweesh/backups');
+const pluginsDir = path.resolve(process.env.HOME, './.sweesh/plugins');
+
+const copyFile = promisify(fs.copyFile);
+const writeFile = promisify(fs.writeFile);
+
+export const command = 'add <app|document-name> [document-path]';
+
+export const describe = 'Add a file to sweesh-cli servers';
+
+export const builder = {
+};
+
+export async function handler(argv: any) {
+    const resolvers = [];
+    let changeIntent = null;
+    if (argv.documentPath) {
+        changeIntent = await resolve([fsResolver], argv.documentPath);
+    } else {
+        // TODO: get all the resolvers from the resolvers directory
+        // TODO: call resolve with all resolvers and the file name
+        changeIntent = await resolve(resolvers, argv.app);
+    }
+    // const rootDir = changeIntent.path.split('/').slice(0, -1).join('/') + '/';
+    // TODO: execute CHANGE intent
+    const backupFile = path.join(backupDir, uuid());
+    // TODO: create dir if it doesn't exist
+    await copyFile(changeIntent.path, backupFile);
+    // TODO: fetch actual file from server
+    writeFile(changeIntent.path, 'Test config file', 'utf8');
+    // TODO: write change log to logger
+};

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -8,10 +8,10 @@ import { promisify } from 'util';
 import resolve from '../utils/resolve';
 import fsResolver from '../utils/fsResolver';
 
-import type {Resolver, ChangeIntent} from '../utils/resolve';
+// import type {Resolver, ChangeIntent} from '../utils/resolve';
 
 const backupDir = path.resolve(process.env.HOME, './.sweesh/backups');
-const pluginsDir = path.resolve(process.env.HOME, './.sweesh/plugins');
+// const pluginsDir = path.resolve(process.env.HOME, './.sweesh/plugins');
 
 const copyFile = promisify(fs.copyFile);
 const writeFile = promisify(fs.writeFile);

--- a/src/utils/fsResolver.js
+++ b/src/utils/fsResolver.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+
+const access = promisify(fs.access);
+
+export async function fn({app: filePath}) {
+    const resolvedPath = path.resolve(process.cwd(), filePath);
+    try {
+        await access(resolvedPath);
+        return {
+            path: resolvedPath
+        };
+    } catch (e) {
+        // Unable to find or access the file
+        return null;
+    }
+};
+
+export const name = 'fs-resolver';
+
+export default {
+    fn,
+    name
+};

--- a/src/utils/resolve.js
+++ b/src/utils/resolve.js
@@ -9,17 +9,17 @@ export type ChangeIntent = {|
 
 export type Resolver = {|
     name: string,
-    fn: (ResolverArgs: {path: string}) => ?ChangeIntent
+    fn: (ResolverArgs: {app: string}) => ?ChangeIntent
 |}
 
-async function resolve(resolvers: Array<Resolver>, path: string): Promise<ChangeIntent> {
-    let resolved = await Promise.all(resolvers.map(({fn}) => fn({path})));
+async function resolve(resolvers: Array<Resolver>, app: string): Promise<ChangeIntent> {
+    let resolved = await Promise.all(resolvers.map(({fn}) => fn({app})));
     resolved = resolved.filter(Boolean);
     if (!resolved.length) {
-        throw Error(`Unable to resolve ${path}`);
+        throw Error(`Unable to resolve ${app}`);
     }
     if (resolved.length > 1) {
-    // TODO: disambiguate from the CLI
+        // TODO: disambiguate from the CLI
     } else {
         return resolved[0];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,7 +3596,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
To test this, run `node lib/index.js add vim ./CONTRIBUTING.md` and this should backup the contributing file, and then replace it with test content